### PR TITLE
support mocha multi reporter

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -104,6 +104,7 @@ class AbstractReporter extends MochaBaseReporter {
             const reporterTryPaths = [
                 `mocha/lib/reporters/${this._options.reporterName}`,
                 this._options.reporterName,
+                `${process.cwd()}/node_modules/mocha-multi/${this._options.reporterName}`,
                 path.resolve(process.cwd(), this._options.reporterName)
             ];
 
@@ -119,6 +120,28 @@ class AbstractReporter extends MochaBaseReporter {
 
         if (!UserReporter) {
             throw new Error(`Invalid reporter "${this._options.reporterName}"`);
+        }
+
+        if (this._options.reporterOptions) {
+            const reports = this._options.reporterOptions.split(',');
+            const reporterOptions = {};
+            
+            for (let report of reports) {
+                const reportProperties = report.split('=');
+                const reportKey = reportProperties[0];
+                const reportValues = reportProperties[1].split(' ');
+                const outPath = reportValues[0];
+
+                if (outPath === '-') {
+                    reporterOptions[reportKey] = outPath;
+                } else {
+                    reporterOptions[reportKey] = {
+                        stdout: outPath
+                    };
+                }
+            }
+
+            this._options.reporterOptions = reporterOptions;
         }
 
         reporterInstance = new UserReporter(this._runnerWrapped, this._options);


### PR DESCRIPTION
Hi, I want to merge it to support mocha multi [issue](https://github.com/yandex/mocha-parallel-tests/issues/136).  I don`t know the process to contribute with this project but I going to trying.

I Added support to  [mocha multi reporter](https://github.com/glenjamin/mocha-multi), it added the path of the mocha multi reporter and it transformed the parameter reporterOptions to work with mocha multi.

to use it from a project that has installed **mocha-parallel-tests** you should:

1. install mocha multi 
      ``` npm install mocha-multi --save-dev ```
1. specify the parameter --reporter or -R and --reporter-options
      ``` mocha-parallel-tests -- --reporter mocha-multi --reporter-options dot=-,xunit=file.xml,doc=docs.html ```

I kept the same format specified in https://github.com/glenjamin/mocha-multi#with---reporter-options

